### PR TITLE
renamed volatiles to methane

### DIFF
--- a/alert/docs/aru_probe_operations_manual.md
+++ b/alert/docs/aru_probe_operations_manual.md
@@ -20,21 +20,21 @@ Monitors ARU and pipeline conditions to ensure ARU operability
 | `PGL`            | label                             | `"PGL"`         |
 
 ## SENSORS
-| Device            | Label       | Purpose                                            |
-|-------------------|-------------|----------------------------------------------------|
-| Pipe Analyzer     | ECL         | Monitors ECL Pipe conditions                       |
-| Pipe Analyzer     | TEC         | Monitors TEC Pipe conditions                       |
-| Pipe Analyzer     | PGL         | Monitors each PGL Pipe conditions                  |
-| Batch Slot Reader | FilterSlot1 | Monitors Slot 0 Quantity of all filtration devices |
-| Batch Slot Reader | FilterSlot2 | Monitors Slot 1 Quantity of all filtration devices |
+| Device            | Label       | Purpose                                                   |
+|-------------------|-------------|-----------------------------------------------------------|
+| Pipe Analyzer     | ECL         | Monitors ECL Pipe conditions                              |
+| Pipe Analyzer     | TEC         | Monitors TEC Pipe conditions                              |
+| Pipe Analyzer     | PGL         | Monitors each PGL Pipe conditions                         |
+| Batch Slot Reader | FilterSlot1 | Monitors Warning Slot Quantity of all filtration devices  |
+| Batch Slot Reader | FilterSlot2 | Monitors Critical Slot Quantity of all filtration devices |
 
 ## ALERT STATES
-| Condition                 | Alert            |
-|---------------------------|------------------|
-| Pipe burst                | 35 (CRITICAL)    |
-| (PGL) Low pressure        | 35 (CRITICAL)    |
-| Secondary filter depleted | 25 (WARN)        |
-| (ECL) High pressure       | 25 (WARN)        |
-| (PGL) High pressure       | 25 (WARN)        |
-| Low temperature           | 25 (WARN)        |
-| Primary filter depleted   | 15 (MAINTENANCE) |
+| Condition                | Alert            |
+|--------------------------|------------------|
+| Pipe burst               | 35 (CRITICAL)    |
+| (PGL) Low pressure       | 35 (CRITICAL)    |
+| Critical filter depleted | 25 (WARN)        |
+| (ECL) High pressure      | 25 (WARN)        |
+| (PGL) High pressure      | 25 (WARN)        |
+| Low temperature          | 25 (WARN)        |
+| Warning filter depleted  | 15 (MAINTENANCE) |

--- a/alert/ic10/alert_console.ic10
+++ b/alert/ic10/alert_console.ic10
@@ -7,9 +7,6 @@ define PercentMode 1
 define FIRE STR("FIRE")
 # Colors
 define DefaultColor 6 # white
-define MethaneColor 4 # red
-define PollutantColor 5 # yellow
-define NitrousOxideColor 2 # green
 
 # Configuration
 define HoldDuration 2 # seconds
@@ -93,23 +90,28 @@ format:
   move DisplayMode    StringMode
   move DisplaySetting FIRE
   jal update
-  # Methane
-  lb r15 GasSensor RatioMethane Average
-  move DisplayColor   MethaneColor
-  move DisplayMode    PercentMode
-  move DisplaySetting r15
-  jal update
-  # Pollutant
+  # Toxic Contaminants
+  move DisplaySetting STR("******")
+  lb r15 GasSensor RatioHydrazine Average
+  breqz r15 2
+  ins DisplaySetting 0 8 STR("Z")
+  lb r15 GasSensor RatioSilanol Average
+  breqz r15 2
+  ins DisplaySetting 8 8 STR("S")
   lb r15 GasSensor RatioPollutant Average
-  move DisplayColor   PollutantColor
-  move DisplayMode    PercentMode
-  move DisplaySetting r15
-  jal update
-  # NitrousOxide
+  breqz r15 2
+  ins DisplaySetting 16 8 STR("P")
   lb r15 GasSensor RatioNitrousOxide Average
-  move DisplayColor   NitrousOxideColor
-  move DisplayMode    PercentMode
-  move DisplaySetting r15
+  breqz r15 2
+  ins DisplaySetting 24 8 STR("N")
+  lb r15 GasSensor RatioMethane Average
+  breqz r15 2
+  ins DisplaySetting 32 8 STR("M")
+  lb r15 GasSensor RatioHydrochloricAcid Average
+  breqz r15 2
+  ins DisplaySetting 40 8 STR("H")
+  move DisplayColor DefaultColor
+  move DisplayMode StringMode
   jal update
   j main
 update:

--- a/alert/ic10/alert_console.ic10
+++ b/alert/ic10/alert_console.ic10
@@ -94,22 +94,22 @@ format:
   move DisplaySetting STR("******")
   lb r15 GasSensor RatioHydrazine Average
   breqz r15 2
-  ins DisplaySetting 0 8 STR("Z")
+  ins DisplaySetting STR("Z") 0 8
   lb r15 GasSensor RatioSilanol Average
   breqz r15 2
-  ins DisplaySetting 8 8 STR("S")
+  ins DisplaySetting STR("S") 8 8
   lb r15 GasSensor RatioPollutant Average
   breqz r15 2
-  ins DisplaySetting 16 8 STR("P")
+  ins DisplaySetting STR("P") 16 8
   lb r15 GasSensor RatioNitrousOxide Average
   breqz r15 2
-  ins DisplaySetting 24 8 STR("N")
+  ins DisplaySetting STR("N") 24 8
   lb r15 GasSensor RatioMethane Average
   breqz r15 2
-  ins DisplaySetting 32 8 STR("M")
+  ins DisplaySetting STR("M") 32 8
   lb r15 GasSensor RatioHydrochloricAcid Average
   breqz r15 2
-  ins DisplaySetting 40 8 STR("H")
+  ins DisplaySetting STR("H") 40 8
   move DisplayColor DefaultColor
   move DisplayMode StringMode
   jal update

--- a/alert/ic10/alert_console.ic10
+++ b/alert/ic10/alert_console.ic10
@@ -7,7 +7,7 @@ define PercentMode 1
 define FIRE STR("FIRE")
 # Colors
 define DefaultColor 6 # white
-define VolatilesColor 4 # red
+define MethaneColor 4 # red
 define PollutantColor 5 # yellow
 define NitrousOxideColor 2 # green
 
@@ -93,9 +93,9 @@ format:
   move DisplayMode    StringMode
   move DisplaySetting FIRE
   jal update
-  # Volatiles
-  lb r15 GasSensor RatioVolatiles Average
-  move DisplayColor   VolatilesColor
+  # Methane
+  lb r15 GasSensor RatioMethane Average
+  move DisplayColor   MethaneColor
   move DisplayMode    PercentMode
   move DisplaySetting r15
   jal update

--- a/alert/ic10/alert_haven.ic10
+++ b/alert/ic10/alert_haven.ic10
@@ -43,7 +43,7 @@ main:
   mul O2 O2 P
   move ContaminantRatio 0
   move ContaminantCount 0
-  lb r15 GasSensor RatioVolatiles Average
+  lb r15 GasSensor RatioMethane Average
   add ContaminantRatio ContaminantRatio r15
   add ContaminantCount ContaminantCount r15
   ceil ContaminantCount ContaminantCount

--- a/alert/ic10/alert_haven.ic10
+++ b/alert/ic10/alert_haven.ic10
@@ -55,6 +55,18 @@ main:
   add ContaminantRatio ContaminantRatio r15
   add ContaminantCount ContaminantCount r15
   ceil ContaminantCount ContaminantCount
+  lb r15 GasSensor RatioHydrazine Average
+  add ContaminantRatio ContaminantRatio r15
+  add ContaminantCount ContaminantCount r15
+  ceil ContaminantCount ContaminantCount
+  lb r15 GasSensor RatioHydrochloricAcid Average
+  add ContaminantRatio ContaminantRatio r15
+  add ContaminantCount ContaminantCount r15
+  ceil ContaminantCount ContaminantCount
+  lb r15 GasSensor RatioSilanol Average
+  add ContaminantRatio ContaminantRatio r15
+  add ContaminantCount ContaminantCount r15
+  ceil ContaminantCount ContaminantCount
 
   move Condition Extreme
   bge P PressureSuitMax main

--- a/aru/docs/README.md
+++ b/aru/docs/README.md
@@ -29,7 +29,7 @@ This checklist must be completed before full system integration.  It ensures all
 5. Power **off** `Failsafe Control`
 6. Power **on** `TEC-FS`
 
-7. Confirm **Methane filters** are installed on `TEC-V`
+7. Confirm **Hydrogen and Methane filters** are installed on `TEC-V`
 8. Power **on** `TEC-V` (unflashed)
 9. Load gas (> 6.3 kPa) from the ECL
 10. Power **on** `Failsafe Control`
@@ -56,7 +56,7 @@ This checklist must be completed before full system integration.  It ensures all
 
 1. Flash the `TEC-V` controller
 2. Power **on** `TEC-V`
-3. Remove filters
+3. Remove at least one filter
 4. Assert `TEC-V` is **IDLE**
 
 6. In case of foreign contamination:

--- a/aru/docs/README.md
+++ b/aru/docs/README.md
@@ -29,7 +29,7 @@ This checklist must be completed before full system integration.  It ensures all
 5. Power **off** `Failsafe Control`
 6. Power **on** `TEC-FS`
 
-7. Confirm **Volatiles filters** are installed on `TEC-V`
+7. Confirm **Methane filters** are installed on `TEC-V`
 8. Power **on** `TEC-V` (unflashed)
 9. Load gas (> 6.3 kPa) from the ECL
 10. Power **on** `Failsafe Control`
@@ -59,7 +59,7 @@ This checklist must be completed before full system integration.  It ensures all
 3. Remove filters
 4. Assert `TEC-V` is **IDLE**
 
-6. In case of volatiles contamination:
+6. In case of methane contamination:
    - Open **manual release valve**
    - Confirm pipe is cleared
 

--- a/aru/docs/README.md
+++ b/aru/docs/README.md
@@ -59,7 +59,7 @@ This checklist must be completed before full system integration.  It ensures all
 3. Remove filters
 4. Assert `TEC-V` is **IDLE**
 
-6. In case of methane contamination:
+6. In case of foreign contamination:
    - Open **manual release valve**
    - Confirm pipe is cleared
 

--- a/aru/docs/tec_system_operations_manual.md
+++ b/aru/docs/tec_system_operations_manual.md
@@ -21,7 +21,7 @@ Pumps waste gases from the **Exchange Capture Line** into the **Thermal Exchange
 
 ### PIPE CONNECTIONS
 * **Input**: Exchange Capture Line
-* **Output**: Volatiles Purge Vent
+* **Output**: Methane Purge Vent
 * **Output2**: PGL Intake and Cooling Loop
 
 ## CONFIGURATION PARAMETERS

--- a/aru/docs/tec_system_operations_manual.md
+++ b/aru/docs/tec_system_operations_manual.md
@@ -21,7 +21,7 @@ Pumps waste gases from the **Exchange Capture Line** into the **Thermal Exchange
 
 ### PIPE CONNECTIONS
 * **Input**: Exchange Capture Line
-* **Output**: Methane Purge Vent
+* **Output**: Contaminants Purge Vent
 * **Output2**: PGL Intake and Cooling Loop
 
 ## CONFIGURATION PARAMETERS

--- a/aru/ic10/aru_tec_intake.ic10
+++ b/aru/ic10/aru_tec_intake.ic10
@@ -50,8 +50,8 @@ pump:
 
   # Idle if the filter is empty
   ls r15 db 0 Quantity
-  ls r14 db 1 Quantity
-  add r15 r15 r14
+  beqz r15 done
+  ls r15 db 1 Quantity
   beqz r15 done
 
   # Idle if pressure is high


### PR DESCRIPTION
See: https://store.steampowered.com/news/app/544550/view/491593545667313734

Volatiles was renamed to Methane as part of the gases update

ARU Probe:
* FilterSlot1 is considered the maintenance filter as it triggers a maintenance alert when it is depleted
* FilterSlot2 is considered the warning filter as it triggers a warning alert when it is depleted.
* Both batch slot readers used to monitor TEC filter life should be labeled FilterSlot2 as there are different filters used to remove methane and hydrogen gases

Vigil
* [Console] Replaced Volatile, Nitrous Oxide, and Pollutant readouts with a single 6-character display showing the presence of toxic contaminants: HMNPSZ => HCl, Methane, Nitrous Oxide, Pollutant, Silanol, Hydrazine
* Haven now checks environments for toxic contaminants

ARU
* TEC-V disables intake if at least one filter slot is depleted since it now removes both hydrogen and methane