### PR TITLE
reduce risk of infinite loop during refinement

### DIFF
--- a/trade/docs/tracking_operations_manual.md
+++ b/trade/docs/tracking_operations_manual.md
@@ -21,8 +21,8 @@ Locks onto a contact's position.
 | Utility | Small  | 0    | 0     | 0       | 300      |
 | Basic   | Small  | 1    | 0     | 0       | 30       |
 | Medium  | Small  | 2    | 20    | 4.5     | 30       |
-| Large   | Medium | 3    | 250   | 8       | 120      |
-| Exotic  | Medium | 4    | 100   | 8       | 1200     |
+| Large   | Medium | 3    | 250   | 8.5     | 120      |
+| Exotic  | Medium | 4    | 100   | 8.5     | 1200     |
 
 ## CONFIGURATION PARAMETERS
 | Variable               | Description                                          | Setting  |
@@ -33,3 +33,17 @@ Locks onto a contact's position.
 | `ScanRatio`            | Scan detection power ratio                           | `0.2`    |
 | `RefineRadius`         | Radial distance for refinement proximity detection   | `15.307` |
 | `RefineAngle`          | Angular step size for refinement proximity detection | `45`     |
+
+# MAINTENANCE & TROUBLESHOOTING
+
+## Dish keeps checking the same positions in a loop
+
+The refinement phase uses a flat-plane approximation to place nine search positions around the detection point.  Near the hemisphere boundary, spherical geometry causes the actual distance between the dish and the contact to be slightly larger than the calculation predicts.  If the contact falls outside the effective coverage of all nine positions, the dish cycles through them repeatedly without resolving.
+
+**Observed behavior:**
+* Dish moves to a position, pauses briefly, then advances to the next
+* Movement traces a circular pattern around the initial detection point
+* Contact is never acquired and the dish does not transition to lock
+* Issue is most prominent for contacts detected at high elevations (V > 70°)
+
+**Solution:** Increase the `Proximity Timeout Setting` in 0.5s increments until the contact transitions to the lock stage.  The timeout extends the dwell time at each position, compensating for the additional spherical distance.  Large and Exotic contacts are most susceptible due to their higher `WattsToResolve` value and are pre-configured with a higher baseline timeout of 8.5s.

--- a/trade/docs/tracking_operations_manual.md
+++ b/trade/docs/tracking_operations_manual.md
@@ -46,4 +46,4 @@ The refinement phase uses a flat-plane approximation to place nine search positi
 * Contact is never acquired and the dish does not transition to lock
 * Issue is most prominent for contacts detected at high elevations (V > 70°)
 
-**Solution:** Increase the `Proximity Timeout Setting` in 0.5s increments until the contact transitions to the lock stage.  The timeout extends the dwell time at each position, compensating for the additional spherical distance.  Large and Exotic contacts are most susceptible due to their higher `WattsToResolve` value and are pre-configured with a higher baseline timeout of 8.5s.
+**Solution:** Increase the `Proximity Timeout Setting` in 0.5s increments until the contact transitions to the lock stage.  The timeout extends the dwell time at each position, compensating for the additional spherical distance.  Large and Exotic contacts are most susceptible due to their higher `WattsToResolve` value and have a higher suggested baseline timeout of 8.5s.

--- a/trade/ic10/trade_dish_track.ic10
+++ b/trade/ic10/trade_dish_track.ic10
@@ -13,15 +13,13 @@ alias DowntimeSetting d4
 
 alias Contact r0
 alias Watts r1
-alias Timeout r2
-alias Downtime r3
-alias Position r4
+alias Downtime r2
+alias Position r3
 
 main:
   s Dish On 1
   l Contact ContactSetting Setting
   l Watts WattsVisibleSetting Setting
-  l Timeout SignalTimeoutSetting Setting
   l Downtime DowntimeSetting Setting
   move Position 0
 scan:
@@ -31,6 +29,7 @@ scan:
   s Dish BestContactFilter -1
   add Position Position ScanStepSize
   mod Position Position AzimuthPeriod
+  beqz Position scan # Prevent divide by 0
   s Dish Horizontal Position
   div r15 90 AzimuthPeriod
   mul r15 r15 Position
@@ -49,7 +48,7 @@ scan:
   l r13 Dish Vertical
   l r12 Dish Horizontal
 refine:
-  mul r11 deg2rad r14
+  mul r11 r14 deg2rad
   sin r10 r11
   mul r10 r10 RefineRadius
   add r10 r10 r13
@@ -80,6 +79,7 @@ lock:
   div r12 r12 r11
   div r12 r12 -2  # (2s_a^2 - s_b^2) / -2s_a
   add r11 r14 r12
+  max r11 r11 1 # Prevent divide by zero
   s Dish Vertical r11
   jal measure
   mul r12 r11 deg2rad
@@ -98,7 +98,8 @@ resolve:
   yield
   l r15 Dish Idle
   beqz r15 resolve
-  sleep Timeout
+  l r15 SignalTimeoutSetting Setting
+  sleep r15
   l r15 Dish SignalID
   bltz r15 scan
   l r15 Dish SignalStrength

--- a/trade/ic10/trade_dish_track.ic10
+++ b/trade/ic10/trade_dish_track.ic10
@@ -29,7 +29,7 @@ scan:
   s Dish BestContactFilter -1
   add Position Position ScanStepSize
   mod Position Position AzimuthPeriod
-  beqz Position scan # Prevent divide by 0
+  beqz Position scan
   s Dish Horizontal Position
   div r15 90 AzimuthPeriod
   mul r15 r15 Position


### PR DESCRIPTION
At some positions near the pole or at the horizon, the dish would get stuck in the refinement stage.  This was caused by two issues:

1. Negative vertical positions near the pole would clamp to 0, reducing scan coverage.
2. Flat plane distortion would reduce the effective search range used with the proximity timeout.

A third issue appeared during lock for contacts near the pole where a V_lock position at 0 would return a divide by zero error.

Fixes:
1. Scan no longer checks pole for contacts.  This would happen when scan needed to make a second pass because the contact spawned sometime after the scan began.  This change doesn't reduce the effectiveness of the spiral as other positions compensate for the loss.
2. Lock clamps to 1 for V-lock calculations that result in values <= 0.  This will result in an increased number of lock steps, but should eventually converge.
3. Proximity scan timeout for large and exotic contacts increased from 8s to 8.5s.  This value is based off of simulated estimates.  Additional tuning may be required and is outlined in the support manual.  The logic now refreshes the timeout value during every refinement check for quicker feedback during tuning.