### PR TITLE
fix PowerActual lookup when checking battery type

### DIFF
--- a/alert/ic10/alert_beacon.ic10
+++ b/alert/ic10/alert_beacon.ic10
@@ -17,14 +17,14 @@ push 1   # Warn - 2
 push 0.5 # Critical - 3
 
 move CategoryOffset sp
-push 6  # All Clear - White
-push 10 # Unused - Pink
-push 11 # Unused - Purple
-push 0  # Unused - Blue
-push 2  # Agriculture - Green
-push 5  # Atmospherics - Yellow
-push 3  # Power - Orange
-push 4  # Environment - Red
+push Color.White  # All Clear
+push Color.Pink   # Security
+push Color.Purple # Customs
+push Color.Blue   # Logistics
+push Color.Green  # Agriculture
+push Color.Yellow # Atmospherics
+push Color.Orange # Power
+push Color.Red    # Environment
 
 s Beacon On 0
 main:

--- a/alert/ic10/alert_probe_aru.ic10
+++ b/alert/ic10/alert_probe_aru.ic10
@@ -9,6 +9,7 @@ define Category 5 # ATMOSPHERE
 define Channel LogicType.Channel5
 
 # Configuration
+define BasePressure 6.3 # kPa
 define MinTemperature 293.15 # K
 define MinPressure 288 # kPa
 define MaxPressure 38908 # kPa
@@ -41,9 +42,14 @@ main:
   beqz r15 update
   lbn r15 PipeAnalyzer ECL Pressure Maximum
   bge r15 MaxPressure update
+  brle r15 BasePressure 3
+  lbn r15 PipeAnalyzer ECL Temperature Minimum
+  ble r15 MinTemperature update
   lbn r15 PipeAnalyzer PGL Pressure Maximum
   bge r15 MaxPressure update
-  lb r15 PipeAnalyzer Temperature Minimum
+  lbn r15 PipeAnalyzer PGL Temperature Minimum
+  ble r15 MinTemperature update
+  lbn r15 PipeAnalyzer TEC Temperature Minimum
   ble r15 MinTemperature update
   move Severity Maintenance
   lbn r15 BatchSlotReader FilterSlot1 Setting Minimum

--- a/power/docs/README.md
+++ b/power/docs/README.md
@@ -5,10 +5,10 @@ This directory contains operational documentation for key infrastructure used in
 ## Available Manuals
 - **[Power Grid Readiness Checklist](#readiness-checklist)**
 - **[Region Control System Operations Manual](./region_operations_manual.md)**
-- **[Zone Control System Operations Manual]()**
+- **[Zone Control System Operations Manual](./zone_operations_manual.md)**
 
 ### Probes
-- **[(6) Grid Probe Operations Manager](../../alert/docs/grid_probe_operations_manual.md)**
+- **[(6) Grid Probe Operations Manual](../../alert/docs/grid_probe_operations_manual.md)**
 
 ## Readiness Checklist
 

--- a/power/docs/region_operations_manual.md
+++ b/power/docs/region_operations_manual.md
@@ -30,4 +30,8 @@ Each connected transformer requires a matching logic reader with an identical la
 
 1.1 Is the region controller setting > 1?
 * IF NO - Load shedding, system normal
-* IF YES - Verify system settings and connections
+* IF YES - Go to STEP 1.2
+
+1.2 Is the budget usage ratio (IC Setting) changing?
+* IF NO - Verify that at least one battery is connected and powered
+* IF YES - Further investigation is required 

--- a/power/ic10/pow_region.ic10
+++ b/power/ic10/pow_region.ic10
@@ -24,9 +24,8 @@ main:
 
   # Calculate actual/requested
   lb r15 Battery PowerActual Average
-  lb r14 BatteryLarge PowerActual Average
-  select r15 r15 r15 r14 # Actual Power
-  bnan r15 main
+  brgez r15 2
+  lb r15 BatteryLarge PowerActual Average
   lb r14 NetworkJunction Setting Sum # Requested power
   lb r13 AreaPowerControl RequiredPower Sum # Uncharacterized loads
   add r14 r14 r13 # Total requested


### PR DESCRIPTION
The power level wasn't changing when upgrading grid batteries to large.  Fixed this by changing the instruction from a select to a branch.

Updated the runbook on instructions for how when the ema appears stuck

### Other fixes
1. Use Color Constants for beacon colors instead of the numerical value
2. Skip freeze pipe warning if the pipe pressure is too low
3. Minor typos in the power documentation