### PR TITLE
Multi sector

### DIFF
--- a/aru/ic10/aru_tec_intake.ic10
+++ b/aru/ic10/aru_tec_intake.ic10
@@ -1,6 +1,5 @@
 define MaxPressure 48636 # kPa
-define MinPressure 6.3 # kPa
-define MaxTemperature 295.15 # K
+define MaxTemperature 298.15 # K
 define MinTemperature 293.15 # K
 
 define MinPressureVolume 10000 # kPa
@@ -46,7 +45,7 @@ pump:
 
   # Idle if there are no input gases
   l r15 db PressureInput
-  blt r15 MinPressure done
+  blez r15 done
 
   # Idle if the filter is empty
   ls r15 db 0 Quantity

--- a/life_support/docs/README.md
+++ b/life_support/docs/README.md
@@ -34,9 +34,10 @@ This checklist must be completed before full system integration.  It ensures all
 
 ### Waste Management Validation
 
-1. Monitor exhaust pressure levels
-2. Assert pumps inactive during normal operation
-3. If exhaust pressure > safety threshold:
+1. Power on controller
+2. Monitor exhaust pressure levels
+3. Assert pumps inactive during normal operation
+4. If exhaust pressure > safety threshold:
    - Verify pump activation
    - Check throughput rates
 

--- a/life_support/docs/README.md
+++ b/life_support/docs/README.md
@@ -57,11 +57,15 @@ Monitor first few atmospheric cycles:
 
 ### System Integration Check
 
+> ⚠️ **Pipe Network Modification:** Before modifying the main bus pipe network, close all local gas network valves.  Disconnecting pipes under pressure can overpressurize local lines.
+
 1. Main/local gas/ line pressure >= 144 kPa?
 2. No pipe ruptures detected?
 3. Valve positions correct?
 
 ### Interconnect Control
+
+> ⚠️ **Thermal Mode Requirement:** If there are thermostats operating in Thermal Tracking Mode, switch to Thermal Pulse Mode before pressurization.  Gas movement during compartment integration can affect PID sampling behavior.  Restore Thermal Tracking Mode after integration is complete and atmospheric conditions have stabilized.
 
 1. Power on controller
 2. Verify the interconnect valve is open

--- a/life_support/docs/mixpress_operations_manual.md
+++ b/life_support/docs/mixpress_operations_manual.md
@@ -1,16 +1,10 @@
 # MIXTURE-PRESSURE CONTROL - SYSTEM OPERATIONS MANUAL
 
 ## SYSTEM PURPOSE
-Regulates sector pressure and atmospheric mixture while maintaining safe exhaust pipe pressures.
+Regulates sector pressure and atmospheric mixture.
 
 ## FUNCTIONAL OVERVIEW
-* Activates ventilation systems to maintain correct atmospheric pressures and gas ratios.
-* Monitors waste pipe pressure to ensure safe levels and activates pumps as needed.
-
-## WASTE MANAGEMENT
-* Monitors local exhaust line pressure
-* Activates pumps when pressure exceeds safety threshold
-* Prevents pipe burst risk near structurally sensitive areas
+Activates ventilation systems to maintain correct atmospheric pressures and gas ratios.
 
 ## INWARD VENTILATION
 * Takes precedence over outward ventilation when sector pressure exceeds target or when a correction is required
@@ -29,7 +23,6 @@ Regulates sector pressure and atmospheric mixture while maintaining safe exhaust
 ## CONFIGURATION PARAMETERS
 | Variable             | Description                                  | Setting                 |
 |----------------------|----------------------------------------------|-------------------------|
-| `SafetyPressure`     | Safety pipe pressure (kPa)                   | `48636`                 |
 | `PressureTolerance`  | Pipe pressure deviation (kPa)                | `3`                     |
 | `MinDisplacement`    | Minimum gas displacement (kPa)               | `0.3`                   |
 | `Delay`              | Delay between atmospheric adjustments (tick) | `2`                     |

--- a/life_support/docs/waste_pump_operations_manual.md
+++ b/life_support/docs/waste_pump_operations_manual.md
@@ -1,0 +1,17 @@
+# WASTE PUMP CONTROL - SYSTEM OPERATIONS MANUAL
+
+## SYSTEM PURPOSE
+Maintains safe exhaust pipe pressures.
+
+## FUNCTIONAL OVERVIEW
+* Monitors local exhaust line pressure
+* Activates pumps when pressure exceeds safety threshold
+* Prevents pipe burst risk near structurally sensitive areas
+
+## HARDWARE INTERFACE
+* **d0:** Pipe Analyzer
+
+## CONFIGURATION PARAMETERS
+| Variable             | Description                                  | Setting                 |
+|----------------------|----------------------------------------------|-------------------------|
+| `SafetyPressure`     | Safety pipe pressure (kPa)                   | `48636`                 |

--- a/life_support/ic10/ls_mixpress.ic10
+++ b/life_support/ic10/ls_mixpress.ic10
@@ -1,44 +1,42 @@
 # Configuration
-define SafetyPressure 48636
 define PressureTolerance 3 # kPa
 define MinDisplacement 0.3 # kPa
 define Delay 2 # tick
 define Precision 0.001
+
 # Labels
 define Local HASH("Sector")
 define LocalCarbonDioxide HASH("SectorCarbonDioxide")
 define LocalNitrogen HASH("SectorNitrogen")
 define LocalOxygen HASH("SectorOxygen")
 define LocalExhaust HASH("SectorExhaust")
+
 # Structures
 define GasSensor HASH("StructureGasSensor")
 define ActiveVent HASH("StructureActiveVent")
-define PipeAnalyzer HASH("StructurePipeAnalysizer")
-define VolumePump HASH("StructureVolumePump")
+
 # Device Ports
 define DeviceRatioCarbonDioxide 2
 define DeviceRatioNitrogen 3
 define DeviceRatioOxygen 4
+
 # Inputs
 alias PressureSetting d0
 alias SizeSetting d1
 alias RatioCarbonDioxideSetting d2
 alias RatioNitrogenSetting d3
 alias RatioOxygenSetting d4
+
 # Variables
 alias GasType r0
 alias RatioType r1
 alias TargetRatio r2
 alias CurrentPressure r3
-alias CurrentPressureTrunc r4
-alias TargetPressure r5
-alias MinPressure r6
-alias PumpVolume r7
-alias Wait r8
+alias TargetPressure r4
+alias MinPressure r5
+alias Wait r6
 
 move Wait 0
-sb PipeAnalyzer On 1
-sb PipeAnalyzer Lock 1
 move sp 0
 main:
   push DeviceRatioCarbonDioxide
@@ -50,25 +48,11 @@ main:
   push DeviceRatioOxygen
   push LogicType.RatioOxygen
   push LocalOxygen
+
 load:
   yield
   sb ActiveVent On 0
   sb ActiveVent Open 1
-  # Check waste pump
-  lbn r15 PipeAnalyzer LocalExhaust Pressure Average
-  lbn r14 PipeAnalyzer LocalExhaust Volume Sum
-  sub r13 r15 SafetyPressure
-  div r13 r13 r15
-  mul PumpVolume r13 r14
-  lbn r15 VolumePump LocalExhaust Maximum Sum
-  lbn r14 VolumePump LocalExhaust Maximum Maximum
-  div r13 r15 r14 # number of devices
-  div r13 PumpVolume r13
-  min r13 r13 r14
-  max r13 r13 0 # pump setting
-  sgtz r12 r13 # pump on
-  sbn VolumePump LocalExhaust Setting r13
-  sbn VolumePump LocalExhaust On r12
   sub Wait Wait 1
   bgtz Wait load
   move Wait 0
@@ -76,9 +60,7 @@ load:
   lbn CurrentPressure GasSensor Local Pressure Average
   l TargetPressure PressureSetting Setting
   sub MinPressure TargetPressure PressureTolerance
-  div CurrentPressureTrunc CurrentPressure Precision
-  floor CurrentPressureTrunc CurrentPressureTrunc
-  mul CurrentPressureTrunc CurrentPressureTrunc Precision
+
 body:
   beqz sp main
   pop GasType
@@ -91,6 +73,7 @@ body:
   push r15
   push RatioType
   push GasType
+
   # Calculate the size of the correction
   sub r13 TargetRatio r14
   sub r12 1 TargetRatio
@@ -99,12 +82,16 @@ body:
   add r13 r13 MinDisplacement
   min r13 r13 PressureTolerance
   sub r13 TargetPressure r13
-  ble CurrentPressureTrunc r13 vent
+  ble CurrentPressure r13 vent
+  bap CurrentPressure r13 Precision vent
   move TargetPressure r13
+
 outward:
-  blt CurrentPressureTrunc MinPressure vent
-  ble CurrentPressureTrunc TargetPressure body
+  blt CurrentPressure MinPressure vent
+  ble CurrentPressure TargetPressure body
+  bap CurrentPressure TargetPressure Precision vent
   move GasType LocalExhaust
+
 vent:
   l r15 SizeSetting Setting
   lbn r14 ActiveVent GasType Open Sum

--- a/life_support/ic10/ls_thermostat.ic10
+++ b/life_support/ic10/ls_thermostat.ic10
@@ -7,8 +7,8 @@ define MaxTTM 1
 define PGainTPM 0.2 # Lower bound T-5K
 define IGainTPM 0
 define DGainTPM 0
-define MinTPM 0
-define MaxTPM 1
+define MinTPM -2
+define MaxTPM 2
 
 # Structures
 define VolumePump HASH("StructureTurboVolumePump")
@@ -24,6 +24,7 @@ alias ModeSetting r0
 alias MaxTemperatureSetting r1
 alias MaxVolumeSetting r2
 alias FlowRate r3
+alias IsReset r4
 
 sb DigitalValve Lock 1
 sb DigitalValve On 0
@@ -33,6 +34,7 @@ sb VolumePump On 0
 
 move ModeSetting -1
 lb MaxVolumeSetting VolumePump Maximum Maximum
+move IsReset 0
 
 main:
   yield
@@ -78,6 +80,7 @@ track:
   max FlowRate FlowRate 0
   min FlowRate FlowRate 1
   s db Setting FlowRate
+  beqz FlowRate reset
 
   sub r15 1 FlowRate
   mul r15 r15 MaxVolumeSetting
@@ -86,17 +89,22 @@ track:
   sb VolumePump Setting r15
   sb VolumePump On r14
   sb DigitalValve On r13
+  move IsReset 0
   j main
 
 pulse:
-  brnez r15 2
+  bge r15 1 reset
+  bgtz r15 main
   sb DigitalValve On 1
-  bne r15 1 main
+  move IsReset 0
+  j main
 
 reset:
+  bnez IsReset main
   sb DigitalValve On 0
   sb VolumePump Setting MaxVolumeSetting
   sb VolumePump On 1
   yield
   sb VolumePump On 0
+  move IsReset 1
   j main

--- a/life_support/ic10/ls_waste_pump.ic10
+++ b/life_support/ic10/ls_waste_pump.ic10
@@ -1,0 +1,31 @@
+# Configuration
+define SafetyPressure 48636
+
+# Structures
+define VolumePump HASH("StructureVolumePump")
+
+# Inputs
+alias PipeAnalyzer d0
+
+# Variables
+alias PumpVolume r0
+
+s PipeAnalyzer On 1
+s PipeAnalyzer Lock 1
+main:
+  yield
+  l r15 PipeAnalyzer Pressure
+  l r14 PipeAnalyzer Volume
+  sub r13 r15 SafetyPressure
+  div r13 r13 r15
+  mul PumpVolume r13 r14
+  lb r15 VolumePump Maximum Sum
+  lb r14 VolumePump Maximum Maximum
+  div r13 r15 r14 # number of devices
+  div r13 PumpVolume r13
+  min r13 r13 r14
+  max r13 r13 0 # pump setting
+  sgtz r12 r13 # pump on
+  sb VolumePump Setting r13
+  sb VolumePump On r12
+  j main


### PR DESCRIPTION
**This is a breaking change for life support systems.**  The mixpress controller no longer handles waste pump evacuation.  This allows for the addition of new life support sectors without requiring the additional infrastructure of adding a new waste pump line.  Review the [updated implementation guide](https://stationeering.substack.com/p/atmospherics-3-life-support-infrastructure) for installation procedures.

### Changes

* Increased the aru-tec-intake MaxTemperature to reduce temperature flapping at low gas pressures
* Removed the 6 kPa pressure minimum for the aru-tec-intake since a pipe analyzer can detect pipe faults on the ECL
* Updated guidance on modifying the main gas lines and added new thermal system requirements when using the interlock control.
* Moved waste evacuation functionality from mixpress and into a separate controller
* Switched to using `bap` instructions for measuring pressure equality in the mix press control
* PID min and max doesn't clamp values as expected, so increased the amounts when a unit is running in pulse mode.
* Added an IsReset flag to the thermostat to prevent the pump from cycling between on and off when cooling is off--should reduce power consumption of the system.