### PR TITLE
improve opportunity discovery algorithm

### DIFF
--- a/trade/docs/pad_resolver_operations_manual.md
+++ b/trade/docs/pad_resolver_operations_manual.md
@@ -23,5 +23,5 @@ Each contact type is assigned a bit position. Setting that bit in the Terminal A
 | Position | Field              | Data Type |
 |----------|--------------------|-----------|
 | 0-7      | CONTACT_SLOT_INDEX | INT_8     |
-| 8-15     | TERMINAL_INDEX     | BYTE_8    |
+| 8-15     | TERMINAL_INDEX     | INT_8     |
 | 16-23    | IS_AVAILABLE       | BYTE_8    |

--- a/trade/ic10/trade_dispatch.ic10
+++ b/trade/ic10/trade_dispatch.ic10
@@ -88,12 +88,14 @@ interrogate:
   yield
   s LandingDish Activate 1
   yield
+  s LandingDish Activate 0
   j main
 loop:
   add Index Index 1
   l r15 ContactSlot Mode
   bgt Index r15 ra
   s ContactSlot Setting Index
+  yield
 check:
   l r15 TrackRegistry Setting
   ext r14 r15 0 8 # CONTACT_SLOT
@@ -109,7 +111,8 @@ check:
   lbn r15 IC ManifestResolver Setting Maximum
   ext r14 r15 0 8 # CONTACT_SLOT
   bne r14 Index check
-  blt r15 $100 loop # HAS_OPPORTUNITY
+  blt r15 $100 check # FOUND_CONTACT
+  blt r15 $200 loop # HAS_OPPORTUNITY
   lbn r15 IC PadResolver Setting Maximum
   ext r14 r15 0 8  # CONTACT_SLOT
   bne r14 Index check

--- a/trade/ic10/trade_manifest_simple_res.ic10
+++ b/trade/ic10/trade_manifest_simple_res.ic10
@@ -68,17 +68,23 @@ main:
   s db Setting Result
   move Result $FF
   yield
+
+  # Check the contact slot
   l Slot ContactSlot Setting
-  l r15 Dish ContactSlotIndex
-  ins Result Slot 0 8
-  bne Slot r15 main
+  l Result Dish ContactSlotIndex
+  bne Slot Result main
+  get r15 Dish 1 # ContactMetaData
+  ext r14 r15 16 8 # CONTACT_SLOT_INDEX
+  bne Slot r14 main
+  ins Result 1 8 8
+
 buy:
   get r15 Dish 3 # BUY
   ext r14 r15 0 8 # OPCODE
   bne r14 TraderInstruction.TraderBuyThingData sell
   ext r14 r15 8 8 # QUANTITY
   beqz r14 sell
-  ins Result 1 8 8
+  ins Result 2 8 8
   j main
 sell:
   get r15 Dish 4  # SELL
@@ -86,5 +92,5 @@ sell:
   bne r14 TraderInstruction.TraderSellThingData main
   ext r14 r15 8 8 # QUANTITY
   beqz r14 main
-  ins Result 1 8 8
+  ins Result 2 8 8
   j main


### PR DESCRIPTION
* Fixup pad resolver document to display terminal index as an int rather than a byte
* Fix opportunity capture behavior which was incorrectly evaluating contacts for matching goods
* Update the simple resolver to send the correct codes on opportunity match 